### PR TITLE
Implement smarthome and smartend commands

### DIFF
--- a/Documentation/dte.txt
+++ b/Documentation/dte.txt
@@ -476,6 +476,14 @@ shift <count>
 	Shift current or selected lines <count> indentation levels.
 	Count is usually -1 (decrease indent) or 1 (increase indent).
 
+smartend
+	Move cursor to end of line; if already there, to end of screen; if
+	already there, to end of file.
+
+smarthome
+	Move cursor to beginning of line; if already there, to beginning of
+	screen; if already there, to beginning of file.
+
 suspend
 	Suspend program. Usually bound to ^Z.
 

--- a/commands.c
+++ b/commands.c
@@ -1196,6 +1196,30 @@ static void cmd_shift(const char *pf, char **args)
 	shift_lines(count);
 }
 
+static void cmd_smartend(const char *pf, char **args)
+{
+	if (! block_iter_eol(&view->cursor)) {
+		long bottom = view->vy + window->edit_h - 1 - window_get_scroll_margin(window);
+		if (view->cy < bottom)
+			move_down(bottom - view->cy);
+		else
+			block_iter_eof(&view->cursor);
+	}
+	view_reset_preferred_x(view);
+}
+
+static void cmd_smarthome(const char *pf, char **args)
+{
+	if (! block_iter_bol(&view->cursor)) {
+		long top = view->vy + window_get_scroll_margin(window);
+		if (view->cy > top)
+			move_up(view->cy - top);
+		else
+			block_iter_bof(&view->cursor);
+	}
+	view_reset_preferred_x(view);
+}
+
 static void cmd_suspend(const char *pf, char **args)
 {
 	suspend();
@@ -1551,6 +1575,8 @@ const struct command commands[] = {
 	{ "set",		"gl",	1, -1, cmd_set },
 	{ "setenv",		"",	2,  2, cmd_setenv },
 	{ "shift",		"",	1,  1, cmd_shift },
+	{ "smartend",		"",	0,  0, cmd_smartend },
+	{ "smarthome",		"",	0,  0, cmd_smarthome },
 	{ "suspend",		"",	0,  0, cmd_suspend },
 	{ "tag",		"r",	0,  1, cmd_tag },
 	{ "toggle",		"glv",	1, -1, cmd_toggle },


### PR DESCRIPTION
Implement smarthome and smartend commands to move the cursor to the beginning/end of line/screenview/page.